### PR TITLE
Update syntax for rofi 1.7

### DIFF
--- a/photon-blue.rasi
+++ b/photon-blue.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-cyan.rasi
+++ b/photon-cyan.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,57 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-green.rasi
+++ b/photon-green.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-orange.rasi
+++ b/photon-orange.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-pink.rasi
+++ b/photon-pink.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-red.rasi
+++ b/photon-red.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-violet.rasi
+++ b/photon-violet.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 

--- a/photon-yellow.rasi
+++ b/photon-yellow.rasi
@@ -17,7 +17,7 @@
     background-color: @bg;
 }
 
-#window {
+window {
     width:            40%;
     border:           2;
     padding:          12;
@@ -25,46 +25,51 @@
     border-color:     @bg-border;
 }
 
-#inputbar {
+inputbar {
     spacing:    0px;
     padding:    0px 5px 0px 5px;
     text-color: @fg;
     children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
 }
 
-#prompt {
+prompt {
     spacing:    0;
     text-color: @fg;
 }
 
-#textbox-prompt-colon {
+textbox-prompt-colon {
     expand:     false;
     str:        ":";
     margin:     0px 0.3em 0em 0em ;
     text-color: @fg;
 }
 
-#entry {
+entry {
     spacing:    5px;
     text-color: @fg;
 }
 
-#listview {
+listview {
     fixed-height: 0;
     spacing:      0px ;
     scrollbar:    false;
     lines:        3;
 }
 
-#element {
+element {
     border:  0;
     padding: 10px 5px 10px 5px;
     background-color: @bg;
     text-color:       @fg;
 }
 
-#element.selected {
+element.selected {
     background-color: @accent-bg;
     text-color:       @accent-fg;
+}
+
+element-text {
+    background-color: inherit;
+    text-color:       inherit;
 }
 


### PR DESCRIPTION
There were some changes in rofi theme syntax in recent releases which break background color of selected items for old themes. Now you should provide `element-text` item to fix this.
Also, according to official rofi themes, leading hash symbols are unnecessary for elements.
This request fixes both problems.